### PR TITLE
Add gulpplugin as a keyword, so it shows in the Gulp repository.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "keywords": [
     "gulp",
-    "brfs"
+    "brfs",
+    "gulpplugin"
   ],
   "author": "George Czabania",
   "license": "MIT",


### PR DESCRIPTION
Allows the plugin to show up here: http://gulpjs.com/plugins/
